### PR TITLE
Upgrade mockk from 1.9.1 to 1.9.3

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -13,8 +13,7 @@ plugin.org.jlleitschuh.gradle.ktlint=8.2.0
 version.com.uchuhimo..konf=0.13.3
 ##             # available=0.22.1
 
-version.io.mockk..mockk=1.9.1
-##          # available=1.9.3
+version.io.mockk..mockk=1.9.3
 
 version.io.moquette..moquette-broker=0.12.1
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.