### PR TITLE
Upgrade kotlintest from 3.3.2 to 3.4.2

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -20,8 +20,7 @@ version.io.moquette..moquette-broker=0.12.1
 
 version.kotlin=1.3.40
 
-version.kotlintest=3.3.2
-##     # available=3.4.2
+version.kotlintest=3.4.2
 
 version.org.eclipse.paho..org.eclipse.paho.client.mqttv3=1.2.2
 ##                                           # available=1.2.3


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.