### PR TITLE
Upgrade org.eclipse.paho.client.mqttv3 from 1.2.2 to 1.2.3

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -23,8 +23,7 @@ version.kotlin=1.3.40
 version.kotlintest=3.3.2
 ##     # available=3.4.2
 
-version.org.eclipse.paho..org.eclipse.paho.client.mqttv3=1.2.2
-##                                           # available=1.2.3
+version.org.eclipse.paho..org.eclipse.paho.client.mqttv3=1.2.3
 
 version.org.jgrapht..jgrapht-core=1.3.1
 ##                    # available=1.4.0


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.