### PR TITLE
Upgrade junit-jupiter-engine from 5.4.2 to 5.6.1

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -32,8 +32,7 @@ version.org.jgrapht..jgrapht-core=1.3.1
 version.org.junit.jupiter..junit-jupiter-api=5.4.2
 ##                               # available=5.6.1
 
-version.org.junit.jupiter..junit-jupiter-engine=5.4.2
-##                                  # available=5.6.1
+version.org.junit.jupiter..junit-jupiter-engine=5.6.1
 
 version.org.mockito..mockito-core=2.1.0
 ##                    # available=3.3.3


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.