### PR TITLE
Upgrade mockito-core from 2.1.0 to 3.3.3

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -35,8 +35,7 @@ version.org.junit.jupiter..junit-jupiter-api=5.4.2
 version.org.junit.jupiter..junit-jupiter-engine=5.4.2
 ##                                  # available=5.6.1
 
-version.org.mockito..mockito-core=2.1.0
-##                    # available=3.3.3
+version.org.mockito..mockito-core=3.3.3
 
 version.org.mockito..mockito-junit-jupiter=2.23.0
 ##                             # available=3.3.3


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.