### PR TITLE
Upgrade mockito-junit-jupiter from 2.23.0 to 3.3.3

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -38,7 +38,6 @@ version.org.junit.jupiter..junit-jupiter-engine=5.4.2
 version.org.mockito..mockito-core=2.1.0
 ##                    # available=3.3.3
 
-version.org.mockito..mockito-junit-jupiter=2.23.0
-##                             # available=3.3.3
+version.org.mockito..mockito-junit-jupiter=3.3.3
 
 version.org.protelis..protelis=13.2.0


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.