### PR TITLE
Upgrade junit-jupiter-engine from 5.6.1 to 5.6.2

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -26,8 +26,9 @@ version.org.eclipse.paho..org.eclipse.paho.client.mqttv3=1.2.3
 version.org.jgrapht..jgrapht-core=1.4.0
 
 version.org.junit.jupiter..junit-jupiter-api=5.6.1
+##                               # available=5.6.2
 
-version.org.junit.jupiter..junit-jupiter-engine=5.6.1
+version.org.junit.jupiter..junit-jupiter-engine=5.6.2
 
 version.org.mockito..mockito-core=2.1.0
 ##                    # available=3.3.3


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.