### PR TITLE
Upgrade moquette-broker from 0.12.1 to 0.13

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -14,7 +14,7 @@ version.com.uchuhimo..konf=0.22.1
 
 version.io.mockk..mockk=1.9.3
 
-version.io.moquette..moquette-broker=0.12.1
+version.io.moquette..moquette-broker=0.13
 
 version.kotlin=1.3.40
 
@@ -25,11 +25,14 @@ version.org.eclipse.paho..org.eclipse.paho.client.mqttv3=1.2.3
 version.org.jgrapht..jgrapht-core=1.4.0
 
 version.org.junit.jupiter..junit-jupiter-api=5.6.1
+##                               # available=5.6.2
 
 version.org.junit.jupiter..junit-jupiter-engine=5.6.1
+##                                  # available=5.6.2
 
 version.org.mockito..mockito-core=3.3.3
 
 version.org.mockito..mockito-junit-jupiter=3.3.3
 
 version.org.protelis..protelis=13.2.0
+##                 # available=13.3.0


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.