### PR TITLE
Upgrade protelis from 13.3.0 to 13.3.2

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -33,4 +33,4 @@ version.org.mockito..mockito-core=3.3.3
 
 version.org.mockito..mockito-junit-jupiter=3.3.3
 
-version.org.protelis..protelis=13.3.0
+version.org.protelis..protelis=13.3.2


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.