### PR TITLE
Upgrade moquette-broker from 0.12.1 to 0.13

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -14,8 +14,7 @@ version.com.uchuhimo..konf=0.22.1
 
 version.io.mockk..mockk=1.9.3
 
-version.io.moquette..moquette-broker=0.12.1
-##                       # available=0.13
+version.io.moquette..moquette-broker=0.13
 
 version.kotlin=1.3.40
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.