### PR TITLE
Upgrade mockk from 1.9.3 to 1.10.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -12,7 +12,7 @@ plugin.org.jlleitschuh.gradle.ktlint=8.2.0
 
 version.com.uchuhimo..konf=0.22.1
 
-version.io.mockk..mockk=1.9.3
+version.io.mockk..mockk=1.10.0
 
 version.io.moquette..moquette-broker=0.13
 
@@ -25,8 +25,10 @@ version.org.eclipse.paho..org.eclipse.paho.client.mqttv3=1.2.4
 version.org.jgrapht..jgrapht-core=1.4.0
 
 version.org.junit.jupiter..junit-jupiter-api=5.6.2
+##                               # available=5.7.0-M1
 
 version.org.junit.jupiter..junit-jupiter-engine=5.6.2
+##                                  # available=5.7.0-M1
 
 version.org.mockito..mockito-core=3.3.3
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.