### PR TITLE
Upgrade protelis from 13.3.5 to 13.3.6

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -32,4 +32,4 @@ version.org.mockito..mockito-core=3.3.3
 
 version.org.mockito..mockito-junit-jupiter=3.3.3
 
-version.org.protelis..protelis=13.3.5
+version.org.protelis..protelis=13.3.6


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.