### PR TITLE
Upgrade mockito-core from 3.4.0 to 3.4.3

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -28,7 +28,7 @@ version.org.junit.jupiter..junit-jupiter-api=5.7.0-M1
 
 version.org.junit.jupiter..junit-jupiter-engine=5.7.0-M1
 
-version.org.mockito..mockito-core=3.4.0
+version.org.mockito..mockito-core=3.4.3
 
 version.org.mockito..mockito-junit-jupiter=3.4.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.