### PR TITLE
Upgrade mockito-junit-jupiter from 3.5.5 to 3.5.7

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -30,6 +30,6 @@ version.org.junit.jupiter..junit-jupiter-engine=5.7.0-M1
 
 version.org.mockito..mockito-core=3.5.7
 
-version.org.mockito..mockito-junit-jupiter=3.5.5
+version.org.mockito..mockito-junit-jupiter=3.5.7
 
 version.org.protelis..protelis=14.0.0


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.