### PR TITLE
Upgrade kotlin from 1.3.40 to 1.3.41

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -21,7 +21,7 @@ version.io.moquette..moquette-broker=0.13
 
 version.junit-jupiter=5.6.2
 
-version.kotlin=1.3.40
+version.kotlin=1.3.41
 
 version.org.eclipse.paho..org.eclipse.paho.client.mqttv3=1.2.5
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.