### PR TITLE
Upgrade junit-jupiter from 5.6.2 to 5.7.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -19,7 +19,7 @@ version.io.mockk..mockk=1.10.0
 
 version.io.moquette..moquette-broker=0.13
 
-version.junit-jupiter=5.6.2
+version.junit-jupiter=5.7.0
 
 version.kotlin=1.4.10
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.