### PR TITLE
Upgrade mockk from 1.10.2 to 1.10.3

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -15,7 +15,7 @@ version..konf=0.23.0
 
 version.io.kotlintest..kotlintest-runner-junit5=3.4.2
 
-version.io.mockk..mockk=1.10.2
+version.io.mockk..mockk=1.10.3
 
 version.io.moquette..moquette-broker=0.13
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.