### PR TITLE
Upgrade git-sensitive-semantic-versioning from 0.2.2 to 0.2.3

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -7,7 +7,7 @@
 
 plugin.com.github.spotbugs=4.6.0
 
-plugin.org.danilopianini.git-sensitive-semantic-versioning=0.2.2
+plugin.org.danilopianini.git-sensitive-semantic-versioning=0.2.3
 
 plugin.org.jlleitschuh.gradle.ktlint=9.4.1
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.