### PR TITLE
Upgrade mockito-core from 3.10.0 to 3.11.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -27,7 +27,7 @@ version.org.eclipse.paho..org.eclipse.paho.client.mqttv3=1.2.5
 
 version.org.jgrapht..jgrapht-core=1.4.0
 
-version.org.mockito..mockito-core=3.10.0
+version.org.mockito..mockito-core=3.11.0
 
 version.org.mockito..mockito-junit-jupiter=version.org.mockito..mockito-core
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.