### PR TITLE
Upgrade mockk from 1.11.0 to 1.12.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -17,7 +17,7 @@ version.de.fraunhofer.iosb.io.moquette..moquette-broker=0.14.3
 
 version.io.kotlintest..kotlintest-runner-junit5=3.4.2
 
-version.io.mockk..mockk=1.11.0
+version.io.mockk..mockk=1.12.0
 
 version.junit-jupiter=5.7.2
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.