### PR TITLE
Upgrade git-sensitive-semantic-versioning from 0.2.3 to 0.3.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,6 @@ allprojects {
         implementation("org.protelis:protelis:_")
     }
 
-    gitSemVer { version = computeGitSemVer() }
     tasks.test { useJUnitPlatform() }
     spotbugs {
         setEffort("max")

--- a/versions.properties
+++ b/versions.properties
@@ -7,7 +7,7 @@
 
 plugin.com.github.spotbugs=4.7.2
 
-plugin.org.danilopianini.git-sensitive-semantic-versioning=0.2.3
+plugin.org.danilopianini.git-sensitive-semantic-versioning=0.3.0
 
 plugin.org.jlleitschuh.gradle.ktlint=10.1.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.