### PR TITLE
ci: use self-hosted runner when configured, fallback to github-hosted

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -7,43 +7,14 @@ jobs:
   find-runner:
     runs-on: ubuntu-latest
     outputs:
-      runner_label: ${{ steps.runner-label.outputs.runner_label }}
+      runner_label: ${{ steps.find-runner.outputs.runner_label }}
     steps:
-      - name: Check if self-hosted config is present
-        id: check-config
-        run: |
-          if [ -n "${{ vars.API_AUTHENTICATION_APP_CLIENT_ID }}" ]; then
-            echo "configured=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "configured=false" >> "$GITHUB_OUTPUT"
-          fi
-      - name: Generate an access installation token
-        id: generate-token
-        if: steps.check-config.outputs.configured == 'true'
-        uses: actions/create-github-app-token@v3
+      - uses: Thesis-repositories/find-runner-action@v1
+        id: find-runner
         with:
-          client-id: ${{ vars.API_AUTHENTICATION_APP_CLIENT_ID }}
-          private-key: ${{ secrets.API_AUTHENTICATION_APP_PRIVATE_KEY }}
-      - name: Call to GitHub API
-        id: api-call
-        if: steps.check-config.outputs.configured == 'true'
-        env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
-        run: |
-          ACTIVE_RUNNERS=$( gh api \
-          -H "Accept: application/vnd.github+json" \
-          -H "X-GitHub-Api-Version: 2026-03-10" \
-          /orgs/Protelis/actions/runners --jq '[.runners[] | select(.status == "online" and .busy == false)] | length')
-          echo "active_runners=$ACTIVE_RUNNERS" >> "$GITHUB_OUTPUT"
-      - name: Write runner-label
-        id: runner-label
-        run: |
-          if [ "${{ steps.check-config.outputs.configured }}" == "true" ] && (( ${{ steps.api-call.outputs.active_runners || 0 }} > 0 ))
-          then
-            echo "runner_label=self-hosted-runners" >> "$GITHUB_OUTPUT"
-          else
-            echo "runner_label=ubuntu-latest" >> "$GITHUB_OUTPUT"
-          fi
+          org: Protelis
+          app-client-id: ${{ vars.API_AUTHENTICATION_APP_CLIENT_ID }}
+          app-private-key: ${{ secrets.API_AUTHENTICATION_APP_PRIVATE_KEY }}
   # Runs all tests
   build:
     needs:

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -4,13 +4,55 @@ on:
   workflow_dispatch:
 
 jobs:
+  find-runner:
+    runs-on: ubuntu-latest
+    outputs:
+      runner_label: ${{ steps.runner-label.outputs.runner_label }}
+    steps:
+      - name: Check if self-hosted config is present
+        id: check-config
+        run: |
+          if [ -n "${{ vars.API_AUTHENTICATION_APP_CLIENT_ID }}" ]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Generate an access installation token
+        id: generate-token
+        if: steps.check-config.outputs.configured == 'true'
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.API_AUTHENTICATION_APP_CLIENT_ID }}
+          private-key: ${{ secrets.API_AUTHENTICATION_APP_PRIVATE_KEY }}
+      - name: Call to GitHub API
+        id: api-call
+        if: steps.check-config.outputs.configured == 'true'
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          ACTIVE_RUNNERS=$( gh api \
+          -H "Accept: application/vnd.github+json" \
+          -H "X-GitHub-Api-Version: 2026-03-10" \
+          /orgs/Protelis/actions/runners --jq '[.runners[] | select(.status == "online" and .busy == false)] | length')
+          echo "active_runners=$ACTIVE_RUNNERS" >> "$GITHUB_OUTPUT"
+      - name: Write runner-label
+        id: runner-label
+        run: |
+          if [ "${{ steps.check-config.outputs.configured }}" == "true" ] && (( ${{ steps.api-call.outputs.active_runners || 0 }} > 0 ))
+          then
+            echo "runner_label=self-hosted-runners" >> "$GITHUB_OUTPUT"
+          else
+            echo "runner_label=ubuntu-latest" >> "$GITHUB_OUTPUT"
+          fi
   # Runs all tests
   build:
+    needs:
+      - find-runner
     strategy:
       matrix:
         os: [ windows, macos, ubuntu ]
       fail-fast: false
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ matrix.os == 'ubuntu' && needs.find-runner.outputs.runner_label || format('{0}-latest', matrix.os) }}
     timeout-minutes: 120
     steps:
       - name: Checkout


### PR DESCRIPTION
Adds a "find-runner" job that checks whether any self-hosted runner is available. If there is at least one, the "build" job's "ubuntu" matrix leg runs on it, otherwise it falls back to "ubuntu-latest". The "windows" and "macos" legs are unaffected and keep running on GitHub-hosted runners.
Before merging no actions are needed, since the first step of the job checks if the self-hosted config is present or not.
To actually route jobs on the self-hosted infrastructure, it is needed to:
- handle ARC authentication, possibly using a GitHub App (https://area4-0.github.io/cluster-doc/github-actions-runners/04-authentication-with-github-app).
- create a variable named API_AUTHENTICATION_APP_CLIENT_ID and a secret named API_AUTHENTICATION_APP_PRIVATE_KEY, these values are used by "actions/create-github-app-token@v3" to make an API call to GitHub. It is possible to use the same App used to authenticate ARC.

```bash
gh variable set API_AUTHENTICATION_APP_CLIENT_ID \
  --org <ORGANIZATION_NAME> \
  --body "<APP_CLIENT_ID>"
```

```bash
gh secret set API_AUTHENTICATION_APP_PRIVATE_KEY \
  --org <ORGANIZATION_NAME> \
  < path/to/your-app-private-key.pem
```
